### PR TITLE
Migrate from google-generativeai to google-genai SDK

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2,10 +2,19 @@ import logging
 import os
 import random
 
-import google.generativeai as genai
+from google import genai
+from google.genai import types
 from torch import Tensor
 
 from .utils import images_to_pillow, temporary_env_var
+
+SAFETY_CATEGORIES = [
+    "HARM_CATEGORY_HATE_SPEECH",
+    "HARM_CATEGORY_HARASSMENT",
+    "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+    "HARM_CATEGORY_DANGEROUS_CONTENT",
+    "HARM_CATEGORY_CIVIC_INTEGRITY",
+]
 
 
 class GeminiNode:
@@ -23,10 +32,12 @@ class GeminiNode:
                     [
                         "gemma-3-12b-it",
                         "gemma-3-27b-it",
-                        "gemini-2.0-flash-lite-001",
-                        "gemini-2.0-flash-001",
                         "gemini-2.5-flash",
+                        "gemini-2.5-flash-lite",
                         "gemini-2.5-pro",
+                        "gemini-3-flash-preview",
+                        "gemini-3.1-pro-preview",
+                        "gemini-3.1-flash-lite-preview",
                     ],
                 ),
             },
@@ -80,21 +91,29 @@ class GeminiNode:
         for image in [image_1, image_2, image_3]:
             if image is not None:
                 images_to_send.extend(images_to_pillow(image))
-        if "GOOGLE_API_KEY" in os.environ and not api_key:
-            genai.configure(transport="rest")
-        else:
-            genai.configure(api_key=api_key, transport="rest")
-        model = genai.GenerativeModel(model, safety_settings=safety_settings, system_instruction=system_instruction)
-        generation_config = genai.GenerationConfig(
-            response_mime_type="application/json" if response_type == "json" else "text/plain"
-        )
+        client_kwargs = {}
+        if api_key or "GOOGLE_API_KEY" not in os.environ:
+            client_kwargs["api_key"] = api_key
+        config_kwargs = {
+            "response_mime_type": "application/json" if response_type == "json" else "text/plain",
+            "safety_settings": [
+                types.SafetySetting(category=cat, threshold=safety_settings) for cat in SAFETY_CATEGORIES
+            ],
+        }
+        if system_instruction:
+            config_kwargs["system_instruction"] = system_instruction
         if temperature is not None and temperature >= 0:
-            generation_config.temperature = temperature
+            config_kwargs["temperature"] = temperature
         if num_predict is not None and num_predict > 0:
-            generation_config.max_output_tokens = num_predict
+            config_kwargs["max_output_tokens"] = num_predict
         try:
             with temporary_env_var("HTTP_PROXY", proxy), temporary_env_var("HTTPS_PROXY", proxy):
-                response = model.generate_content([prompt, *images_to_send], generation_config=generation_config)
+                client = genai.Client(**client_kwargs)
+                response = client.models.generate_content(
+                    model=model,
+                    contents=[prompt, *images_to_send],
+                    config=types.GenerateContentConfig(**config_kwargs),
+                )
             self.text_output = response.text
         except Exception:
             if error_fallback_value is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = [ "google-generativeai>=0.8.5" ]
+dependencies = [ "google-genai>=1.0.0" ]
 urls.Changelog = "https://github.com/Visionatrix/ComfyUI-Gemini/blob/main/CHANGELOG.md"
 urls.Repository = "https://github.com/Visionatrix/ComfyUI-Gemini"
 urls.Source = "https://github.com/Visionatrix/ComfyUI-Gemini"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = [ "google-genai>=1.0.0" ]
+dependencies = [ "google-genai>=1" ]
 urls.Changelog = "https://github.com/Visionatrix/ComfyUI-Gemini/blob/main/CHANGELOG.md"
 urls.Repository = "https://github.com/Visionatrix/ComfyUI-Gemini"
 urls.Source = "https://github.com/Visionatrix/ComfyUI-Gemini"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 torch
 pillow
 numpy
-google-generativeai>=0.8.3
+google-genai>=1.0.0


### PR DESCRIPTION
  Summary

  - Migrates the project from the legacy google-generativeai SDK to the new official google-genai SDK (>=1.0.0)
  - Updates the API usage to the new client-based pattern (genai.Client + client.models.generate_content) replacing the old genai.configure + GenerativeModel approach
  - Adds newer Gemini model options (Gemini 3.x series, 2.5 Flash Lite) and removes deprecated ones (2.0 Flash/Lite 001)
  - Explicitly defines safety setting categories using types.SafetySetting for compatibility with the new SDK